### PR TITLE
ci: デプロイワークフロー追加、テストレポート保存・配信設定

### DIFF
--- a/.github/workflows/deploy_to_production.yaml
+++ b/.github/workflows/deploy_to_production.yaml
@@ -1,0 +1,39 @@
+name: Deploy to Production
+
+run-name: Deploy to Production
+
+on:
+  workflow_run:
+    workflows:
+      - "Run E2E Test"
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Railway
+        run: bash <(curl -fsSL cli.new)
+
+      - name: Link to the environment
+        run: railway environment production
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+
+      - name: Deploy
+        run: railway up --ci --service fastify-webapp-sample
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}

--- a/.github/workflows/run-e2e-test.yaml
+++ b/.github/workflows/run-e2e-test.yaml
@@ -53,8 +53,8 @@ jobs:
         if: always()
         with:
           gh-pages: gh-pages
-          allure_history: allure-history
-          allure_results: e2e/allure-results
+          allure_results: e2e/allure-results  # このデータを基に、
+          allure_history: allure-history      # このディレクトリにレポートを生成
 
       - name: Publish test report
         uses: peaceiris/actions-gh-pages@v4
@@ -62,4 +62,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: allure-history
+          publish_dir: allure-history         # レポートをGitHub Pagesへ配信

--- a/.github/workflows/run-e2e-test.yaml
+++ b/.github/workflows/run-e2e-test.yaml
@@ -39,3 +39,27 @@ jobs:
         env:
           BASE_URL: "fastify-webapp-sample-staging-9128.up.railway.app"
           HEADLESS: true
+
+      - name: Load test report history
+        uses: actions/checkout@v4
+        if: always()
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          pages: gh-pages
+
+      - name: Build test report
+        uses: simple-elf/allure-report-action@v1.7
+        if: always()
+        with:
+          gh-pages: gh-pages
+          allure_history: allure-history
+          allure_results: e2e/allure-results
+
+      - name: Publish test report
+        uses: peaceiris/actions-gh-pages@v4
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: allure-history

--- a/.github/workflows/run-e2e-test.yaml
+++ b/.github/workflows/run-e2e-test.yaml
@@ -1,0 +1,41 @@
+name: Run E2E Test
+
+run-name: Run E2E Test
+
+on:
+  workflow_run:
+    workflows:
+      - "Deploy to Staging"
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  run-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
+        working-directory: ./e2e
+
+      - name: Setup E2E Test
+        run: npm ci
+        working-directory: ./e2e
+
+      - name: Run E2E Test
+        run: npm run Test
+        working-directory: ./e2e
+        env:
+          BASE_URL: "fastify-webapp-sample-staging-9128.up.railway.app"
+          HEADLESS: true


### PR DESCRIPTION
- E2Eテスト実行ワークフローを追加（Staging環境へのデプロイ完了後に実行）
- Production環境へのデプロイワークフローを追加（E2Eテスト実行ワークフロー完了後に実行）
- GitHub Pagesへテストレポートを保存・配信できるように設定