### PR TITLE
refactor: `devcontainer`改善

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     // "onCreateCommand": {
     //     "npm-install": "set -ex && npm i",
     //     // TODO: 実行のたびにPlaywrightインストールが行われるため、インストール済の場合はスキップできるようにしたい
-    //     "npm-install-e2e": "set -ex && cd e2e && npm i && npx playwright install --with-deps"
+    //     "npm-install-e2e": "set -ex && cd e2e && npm i && npx playwright install-deps && npx playwright install"
     // },
     "customizations": {
         "vscode": {

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -12,7 +12,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 # Javaのインストール
 # NOTE: Allure Reportのレポート生成に必要
-RUN apt install -y openjdk-17-jdk
+# NOTE: [インストール参考] https://hub.docker.com/_/eclipse-temurin
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 ARG USERNAME=vscode
 ARG GROUPNAME=vscode

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -8,7 +8,8 @@ RUN apt update && apt upgrade
 
 # Node.jsのインストール
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt install -y nodejs
+    && apt install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 # Javaのインストール
 # NOTE: Allure Reportのレポート生成に必要


### PR DESCRIPTION
1. Java（JDK）インストール方法を、公式記載の方法に変更
   - https://hub.docker.com/_/eclipse-temurin
2. Node.jsのインストールを、公式imageから必要ファイルをコピーする方式に変更
   - 併せて、Node.jsの起動方法に問題がありそうだったので、`tini` 経由で起動するように修正
   - [【Dockerfile】Node.jsをバージョン指定でインストールする2つの方法](https://note.milldea.com/posts/two-ways-to-install-nodejs-with-fixed-version-in-dockerfile)
   - [Node.js Docker baseイメージには alpine < distroless < ubuntu+slim 構成がよさそう](https://zenn.dev/jrsyo/articles/e42de409e62f5d)
3. Playwrightの依存ライブラリインストール手順を分割
   - ブラウザのインストールに時間がかかり、タイムアウトしてしまうため
   - もう少し良いやり方がありそう
   - 依存ライブラリ参考: https://qiita.com/piggydev/items/076af556ff97e92119b4